### PR TITLE
ENH?: don't eval across modules in macroexpansion

### DIFF
--- a/src/JSExpr.jl
+++ b/src/JSExpr.jl
@@ -174,7 +174,7 @@ function jsexpr(x::Expr)
         a_[] => obs_get_expr(a)
         a_[i__] => ref_expr(a, i...)
         [xs__] => vect_expr(xs)
-        (@m_ xs__) => jsexpr(macroexpand(x))
+        (@m_ xs__) => jsexpr(macroexpand(current_module(), x))
         (for i_ = start_ : to_
             body__
         end) => for_expr(i, start, to, body)

--- a/src/JSExpr.jl
+++ b/src/JSExpr.jl
@@ -1,7 +1,7 @@
 module JSExpr
 
 using JSON, MacroTools, WebIO
-export JSString, @js, @js_str
+export JSString, @js, @js_str, @var, @new
 
 import WebIO: JSString, JSONContext, JSEvalSerialization
 

--- a/src/JSExpr.jl
+++ b/src/JSExpr.jl
@@ -174,7 +174,7 @@ function jsexpr(x::Expr)
         a_[] => obs_get_expr(a)
         a_[i__] => ref_expr(a, i...)
         [xs__] => vect_expr(xs)
-        (@m_ xs__) => jsexpr(macroexpand(JSExpr, x))
+        (@m_ xs__) => jsexpr(macroexpand(x))
         (for i_ = start_ : to_
             body__
         end) => for_expr(i, start, to, body)


### PR DESCRIPTION
Not sure if this is a good idea in general, but this did fix the following error:

```
WARNING: eval from module JSExpr to PlotlyWebIO:    
Expr(:call, :macroexpand, quote Expr(:macrocall, :@var, :gd = Expr(:call, Expr(:., Expr(:., :this, Expr(:quote, :dom)::Any)::Any, Expr(:quote, :querySelector)::Any)::Any, Expr(:$, :id)::Any)::Any)::Any end)::Any
  ** incremental compilation may be broken for this module **

WARNING: eval from module JSExpr to PlotlyWebIO:    
Expr(:call, :macroexpand, quote Expr(:macrocall, :@var, :svg_data = Expr(:call, Expr(:., :data, Expr(:quote, :replace)::Any)::Any, "data:image/svg+xml,", "")::Any)::Any end)::Any
  ** incremental compilation may be broken for this module **

WARNING: eval from module JSExpr to PlotlyWebIO:    
Expr(:call, :macroexpand, quote Expr(:macrocall, :@var, :filtered_data = Expr(:call, Expr(:., Expr(:., Expr(:., :WebIO, Expr(:quote, :CommandSets)::Any)::Any, Expr(:quote, :Plotly)::Any)::Any, Expr(:quote, :filterEventData)::Any)::Any, :gd, :data, "hover")::Any)::Any end)::Any
  ** incremental compilation may be broken for this module **

WARNING: eval from module JSExpr to PlotlyWebIO:    
Expr(:call, :macroexpand, quote Expr(:macrocall, :@var, :filtered_data = Expr(:call, Expr(:., Expr(:., Expr(:., :WebIO, Expr(:quote, :CommandSets)::Any)::Any, Expr(:quote, :Plotly)::Any)::Any, Expr(:quote, :filterEventData)::Any)::Any, :gd, :data, "selected")::Any)::Any end)::Any
  ** incremental compilation may be broken for this module **

WARNING: eval from module JSExpr to PlotlyWebIO:    
Expr(:call, :macroexpand, quote Expr(:macrocall, :@var, :filtered_data = Expr(:call, Expr(:., Expr(:., Expr(:., :WebIO, Expr(:quote, :CommandSets)::Any)::Any, Expr(:quote, :Plotly)::Any)::Any, Expr(:quote, :filterEventData)::Any)::Any, :gd, :data, "relayout")::Any)::Any end)::Any
  ** incremental compilation may be broken for this module **

WARNING: eval from module JSExpr to PlotlyWebIO:    
Expr(:call, :macroexpand, quote Expr(:macrocall, :@var, :filtered_data = Expr(:call, Expr(:., Expr(:., Expr(:., :WebIO, Expr(:quote, :CommandSets)::Any)::Any, Expr(:quote, :Plotly)::Any)::Any, Expr(:quote, :filterEventData)::Any)::Any, :gd, :data, "click")::Any)::Any end)::Any
  ** incremental compilation may be broken for this module **

WARNING: eval from module JSExpr to PlotlyWebIO:    
Expr(:call, :macroexpand, quote Expr(:macrocall, :@var, :gd = Expr(:call, Expr(:., Expr(:., :this, Expr(:quote, :dom)::Any)::Any, Expr(:quote, :querySelector)::Any)::Any, Expr(:$, :id)::Any)::Any)::Any end)::Any
  ** incremental compilation may be broken for this module **

WARNING: eval from module JSExpr to PlotlyWebIO:    
Expr(:call, :macroexpand, quote Expr(:macrocall, :@var, :svg_data = Expr(:call, Expr(:., :data, Expr(:quote, :replace)::Any)::Any, "data:image/svg+xml,", "")::Any)::Any end)::Any
  ** incremental compilation may be broken for this module **

WARNING: eval from module JSExpr to PlotlyWebIO:    
Expr(:call, :macroexpand, quote Expr(:macrocall, :@var, :svg_data = Expr(:call, Expr(:., :data, Expr(:quote, :replace)::Any)::Any, "data:image/svg+xml,", "")::Any)::Any end)::Any
  ** incremental compilation may be broken for this module **

WARNING: eval from module JSExpr to PlotlyWebIO:    
Expr(:call, :macroexpand, quote Expr(:macrocall, :@var, :gd = Expr(:call, Expr(:., Expr(:., :this, Expr(:quote, :dom)::Any)::Any, Expr(:quote, :querySelector)::Any)::Any, Expr(:$, :id)::Any)::Any)::Any end)::Any
  ** incremental compilation may be broken for this module **

WARNING: eval from module JSExpr to PlotlyWebIO:    
Expr(:call, :macroexpand, quote Expr(:macrocall, :@var, :svg_data = Expr(:call, Expr(:., :data, Expr(:quote, :replace)::Any)::Any, "data:image/svg+xml,", "")::Any)::Any end)::Any
  ** incremental compilation may be broken for this module **
```

The export of `@var` and `@new` makes sure that if user code uses those macros after calling `using JSExpr`