### PR TITLE
Revert "expand macros in JSExpr instead of current_module()"

### DIFF
--- a/src/JSExpr.jl
+++ b/src/JSExpr.jl
@@ -176,7 +176,7 @@ function jsexpr(x::Expr)
         a_[] => obs_get_expr(a)
         a_[i__] => ref_expr(a, i...)
         [xs__] => vect_expr(xs)
-        (@m_ xs__) => jsexpr(macroexpand(JSExpr, x))
+        (@m_ xs__) => jsexpr(macroexpand(current_module(), x))
         (for i_ = start_ : to_
             body__
         end) => for_expr(i, start, to, body)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,17 +81,3 @@ end
         @test @js($ob[] = 1) == js"WebIO.setval({\"name\":\"test\",\"scope\":\"testwidget2\",\"id\":\"ob_02\",\"type\":\"observable\"},1)"
     end
 end
-
-# https://github.com/JuliaGizmos/JSExpr.jl/issues/13
-module OuterWrapper
-    module InnerWrapper
-        import JSExpr: jsexpr
-        f() = jsexpr(:(@new(1)))
-    end
-
-    using Base.Test
-    @testset "Issue 13" begin
-        InnerWrapper.f()
-    end
-end
-


### PR DESCRIPTION
Reverts JuliaGizmos/JSExpr.jl#14