### PR TITLE
support abstractobservable in interpolation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.7
 JSON
 MacroTools
 WebIO 0.3.0
+Observables 0.2.2

--- a/src/JSExpr.jl
+++ b/src/JSExpr.jl
@@ -6,6 +6,7 @@ using JSON, MacroTools, WebIO
 export JSString, @js, @js_str, @var, @new
 
 import WebIO: JSString, JSONContext, JSEvalSerialization
+using Observables: AbstractObservable
 
 macro js(expr)
     :(JSString(string($(jsstring(expr)...))))
@@ -54,7 +55,7 @@ function obs_set_expr(x, val)
     F(["WebIO.setval(", jsexpr_joined([x, val]), ")"])
 end
 
-function jsexpr(o::WebIO.Observable)
+function jsexpr(o::AbstractObservable)
     if !haskey(WebIO.observ_id_dict, o)
         error("No scope associated with observer being interpolated")
     end


### PR DESCRIPTION
This, together with https://github.com/JuliaGizmos/WebIO.jl/pull/179, allows to use a general `AbstractObservable` rather than just a concrete `Observable` in a `Scope`.