### PR TITLE
Parse named tuples into JS object properties

### DIFF
--- a/src/JSExpr.jl
+++ b/src/JSExpr.jl
@@ -108,7 +108,9 @@ end
 function dict_expr(xs)
     parts = []
     xs = map(xs) do x
-        if x.head == :(=) || x.head == :kw
+        if !isa(x, Expr)
+            error("Invalid pair separator in dict expression")
+        elseif x.head == :(=) || x.head == :kw
             push!(parts, F([jsexpr(x.args[1]), ":", jsexpr(x.args[2])]))
         elseif x.head == :call && x.args[1] == :(=>)
             push!(parts, F([jsexpr(x.args[2]), ":", jsexpr(x.args[3])]))
@@ -189,6 +191,7 @@ function jsexpr(x::Expr)
         $(Expr(:$, :_)) => inter(x.args[1])
         $(Expr(:new, :c_)) => F(["new ", jsexpr(x.args[1])])
         $(Expr(:var, :c_)) => F(["var ", jsexpr(x.args[1])])
+        $(Expr(:tuple, :__)) => dict_expr(x.args)
         _ => error("JSExpr: Unsupported `$(x.head)` expression, $x")
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,7 @@ end
 
 
     @test @js(d(x=1)) == js"{x:1}" # special dict syntax
+    @test @js((x=1,)) == js"{x:1}" # named tuple syntax
     @test @js(d("x\"y"=1)) == JSString("{\"x\\\"y\":1}")
     @test @js([1, "xyz"]) == js"[1,\"xyz\"]"
 


### PR DESCRIPTION
Closes #19. Catch tuples last in the expression parser, because of the generality of braces, then in the dictionary parser ensure the arguments are all expressions, to avoid "head not found" errors.