### PR TITLE
Fix deprecation from WebIO 0.8 and restrict version compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,5 +10,5 @@ WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
 
 [compat]
 Observables = "≥ 0.2.2"
-WebIO = "≥ 0.7.0"
-julia = "≥ 0.7.0"
+WebIO = "0.7"
+julia = "0.7, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,14 @@
+name = "JSExpr"
+uuid = "97c1335a-c9c5-57fe-bc5d-ec35cebe8660"
+
+[deps]
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
+
+[compat]
+Observables = "≥ 0.2.2"
+WebIO = "≥ 0.7.0"
+julia = "≥ 0.7.0"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
 
 [compat]
-Observables = "≥ 0.2.2"
-WebIO = "0.7"
+Observables = "0.2.2"
+WebIO = "0.8"
 julia = "0.7, 1"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,0 @@
-julia 0.7
-JSON
-MacroTools
-WebIO 0.7.0
-Observables 0.2.2

--- a/src/JSExpr.jl
+++ b/src/JSExpr.jl
@@ -5,7 +5,7 @@ module JSExpr
 using JSON, MacroTools, WebIO
 export JSString, @js, @js_str, @var, @new
 
-import WebIO: JSString, JSONContext, JSEvalSerialization
+import WebIO: JSString, JSONContext, JSEvalSerialization, scopeid
 using Observables: AbstractObservable
 
 macro js(expr)
@@ -64,7 +64,7 @@ function jsexpr(o::AbstractObservable)
     scope = _scope.value
 
     obsobj = Dict("type" => "observable",
-                  "scope" => scope.id,
+                  "scope" => scopeid(scope),
                   "name" => name,
                   "id" => WebIO.obsid(o))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,14 +70,14 @@ end
     end) == js"var acc=0; for(var i = 1; i <= 10; i = i + 2){acc+=1}"
 
     @testset "observable interpolation" begin
-        w = Scope("testwidget2")
+        w = Scope()
         ob = Observable(0)
         @test_throws ErrorException @js $ob
 
         ob = Observable{Any}(w, "test", nothing)
-        @test @js($ob) == js"{\"name\":\"test\",\"scope\":\"testwidget2\",\"id\":\"ob_02\",\"type\":\"observable\"}"
+        @test @js($ob) == js"{\"name\":\"test\",\"scope\":$(WebIO.scopeid(w)),\"id\":\"ob_02\",\"type\":\"observable\"}"
 
-        @test @js($ob[]) == js"WebIO.getval({\"name\":\"test\",\"scope\":\"testwidget2\",\"id\":\"ob_02\",\"type\":\"observable\"})"
-        @test @js($ob[] = 1) == js"WebIO.setval({\"name\":\"test\",\"scope\":\"testwidget2\",\"id\":\"ob_02\",\"type\":\"observable\"},1)"
+        @test @js($ob[]) == js"WebIO.getval({\"name\":\"test\",\"scope\":$(WebIO.scopeid(w)),\"id\":\"ob_02\",\"type\":\"observable\"})"
+        @test @js($ob[] = 1) == js"WebIO.setval({\"name\":\"test\",\"scope\":$(WebIO.scopeid(w)),\"id\":\"ob_02\",\"type\":\"observable\"},1)"
     end
 end


### PR DESCRIPTION
On top of #27 

Uses `scopeid(scope)` instead of `scope.id`. 

This also changes the compat section of the `Project.toml` to change the `>=` version specifiers to the default version specifier, which allows any upgrade compatible with semver. This means that JSExpr won't automatically try to work with some future WebIO 0.9, which should help keep the ecosystem a bit more stable. When WebIO 0.9 does come out, we can just update JSExpr's compat section to declare compatibility (if it is, in fact, compatible). 