### PR TITLE
Update WebIO requirement

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JSExpr"
 uuid = "97c1335a-c9c5-57fe-bc5d-ec35cebe8660"
 license = "MIT"
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -13,7 +13,7 @@ WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
 JSON = "0.18, 0.19, 0.20, 0.21"
 MacroTools = "0.4, 0.5"
 Observables = "0.2.2, 0.3, 0.4"
-WebIO = "0.8.5"
+WebIO = "0.8.15"
 julia = "0.7, 1"
 
 [extras]


### PR DESCRIPTION
Transition to the most recent version of WebIO which is required for recent releases of Makie. At least the unit tests, PlotlyJS, and Makie do work. I have not conducted further tests.